### PR TITLE
Dirmethod

### DIFF
--- a/pythas/core.py
+++ b/pythas/core.py
@@ -60,11 +60,11 @@ class PythasLoader(Loader):
         shared_libs = create_shared_libs(ffi_files, ffi_pinfos)
         libs = [(cdll.LoadLibrary(libname),info) for libname, info in shared_libs]
         exported = [list(info.exported_ffi) for _,info in libs]
-        new_dir = dir(module) + reduce(lambda a,b:a+b, exported)
 
         module._ffi_libs = libs
         module.__getattr__ = partial(custom_attr_getter, module)
-        module.__dir__ = lambda: new_dir
+
+        module.__dir__ = lambda: list(module.__dict__.keys()) + reduce(lambda a,b:a+b, exported)
 
 def create_shared_libs(ffi_files, ffi_pinfos):
     yield from (ghc_compile(fn, info) for fn,info in zip(ffi_files, ffi_pinfos))

--- a/pythas/core.py
+++ b/pythas/core.py
@@ -58,10 +58,9 @@ class PythasLoader(Loader):
             print("Got File: " +f)
         ffi_pinfos = map(parse_haskell,ffi_files)
         shared_libs = create_shared_libs(ffi_files, ffi_pinfos)
-        exported = [list(info.exported_ffi) for _,info in shared_libs]
-        new_dir = dir(module) + reduce(lambda a,b:a+b, exported)
-
         libs = [(cdll.LoadLibrary(libname),info) for libname, info in shared_libs]
+        exported = [list(info.exported_ffi) for _,info in libs]
+        new_dir = dir(module) + reduce(lambda a,b:a+b, exported)
 
         module._ffi_libs = libs
         module.__getattr__ = partial(custom_attr_getter, module)

--- a/pythas/core.py
+++ b/pythas/core.py
@@ -2,7 +2,7 @@ from importlib.abc import Loader, MetaPathFinder
 from importlib.util import spec_from_file_location
 from subprocess import run
 from ctypes import cdll
-from functools import partial
+from functools import partial, reduce
 from sys import meta_path, platform
 import os.path
 
@@ -57,10 +57,15 @@ class PythasLoader(Loader):
         for f in ffi_files:
             print("Got File: " +f)
         ffi_pinfos = map(parse_haskell,ffi_files)
-        libs = [(cdll.LoadLibrary(libname),info)
-            for libname,info in create_shared_libs(ffi_files, ffi_pinfos)]
-        setattr(module, 'ffi_libs', libs)
+        shared_libs = create_shared_libs(ffi_files, ffi_pinfos)
+        exported = [list(info.exported_ffi) for _,info in shared_libs]
+        new_dir = dir(module) + reduce(lambda a,b:a+b, exported)
+
+        libs = [(cdll.LoadLibrary(libname),info) for libname, info in shared_libs]
+
+        module._ffi_libs = libs
         module.__getattr__ = partial(custom_attr_getter, module)
+        module.__dir__ = lambda: new_dir
 
 def create_shared_libs(ffi_files, ffi_pinfos):
     yield from (ghc_compile(fn, info) for fn,info in zip(ffi_files, ffi_pinfos))
@@ -79,3 +84,4 @@ def ghc_compile(filename, parse_info):
 
 def install():
     meta_path.insert(0, PythasMetaFinder())
+

--- a/pythas/utils.py
+++ b/pythas/utils.py
@@ -49,8 +49,12 @@ def find_source(name, path, extension='.hs'):
         return []
 
 def custom_attr_getter(obj, name):
-    ffi_libs = obj.ffi_libs
-    not_found = AttributeError("{} object has no attribute {} and no Haskell module containing it.".format(obj.__name__,repr(name)))
+    ffi_libs = obj._ffi_libs
+    not_found = AttributeError(
+            "{} object has no attribute {}"
+            "and no Haskell module containing it."
+            "".format(obj.__name__,repr(name))
+            )
     for lib, info in ffi_libs:
         if name in info.exported_ffi:
             f = getattr(lib,name)

--- a/pythas/utils.py
+++ b/pythas/utils.py
@@ -51,7 +51,7 @@ def find_source(name, path, extension='.hs'):
 def custom_attr_getter(obj, name):
     ffi_libs = obj._ffi_libs
     not_found = AttributeError(
-            "{} object has no attribute {}"
+            "{} object has no attribute {} "
             "and no Haskell module containing it."
             "".format(obj.__name__,repr(name))
             )
@@ -72,10 +72,12 @@ def custom_attr_getter(obj, name):
 
 def check_ctype_seq(seq):
     def _check(seq):
-        return any(not isinstance(e, _SimpleCData) if not isinstance(e,abc.Iterable) else _check(e) for e in seq)
+        return any(not isinstance(e, _SimpleCData)
+                if not isinstance(e,abc.Iterable) else _check(e)
+                for e in seq)
 
     if not _check(seq):
-        raise TypeError('Only sequences of <ctypes._SimpleCData allowed.')
+        raise TypeError('Only sequences of <ctypes._SimpleCData> allowed.')
     else:
         return seq
 
@@ -84,5 +86,8 @@ def is_constant(func_infos):
 
 def check_has_ghc():
     if not (which('ghc') or which('stack')):
-        raise ImportError('No GHC found. Please install either Stack or GHC and make sure that either is in your $PATH.')
+        raise ImportError('No GHC found. '
+        'Please install either Stack or GHC '
+        'and make sure that either is in your $PATH.'
+        )
 


### PR DESCRIPTION
Calling ```dir``` on a Haskell module imported with ```pythas``` will not show useful information (i.e. the available namespace in the Haskell module) so far. This PR creates a static list containing the basic output of ```dir``` on the module **plus** the names exported from Haskell.