### PR TITLE
Tupleargs

### DIFF
--- a/example/Example.hs
+++ b/example/Example.hs
@@ -33,6 +33,9 @@ strings = filter (/= 'a')
 nested :: [[String]] -> [[String]]
 nested = id
 
-tuple :: (CInt, String) -> (CInt, String)
-tuple = id -- (1 :: CInt, "a")
+tuple :: (Int, String)
+tuple = (1, "a")
+
+hsnd :: (Int, Int) -> Int
+hsnd (_,b) = b
 

--- a/example/Example.hs
+++ b/example/Example.hs
@@ -33,5 +33,6 @@ strings = filter (/= 'a')
 nested :: [[String]] -> [[String]]
 nested = id
 
-tuple :: (CInt, String)
-tuple = (1 :: CInt, "a")
+tuple :: (CInt, String) -> (CInt, String)
+tuple = id -- (1 :: CInt, "a")
+

--- a/pythas/haskell/parse_type.py
+++ b/pythas/haskell/parse_type.py
@@ -60,12 +60,10 @@ def hs2py(hs_type):
     if hs_type == '':
         hs_type = '()'
     default = lambda _:simple_hs_2_py(hs_type)
-    def hs_tuple(f):
-        return lambda hs_inner:cl.POINTER(f(*map(hs2py,tuple_types(hs_inner))))
     parse = parse_generator(
             lambda hs_inner:cl.POINTER(new_linked_list(hs2py(hs_inner))),
             lambda hs_inner:cl.POINTER(new_c_array(hs2py(hs_inner))),
-            hs_tuple(new_tuple2), hs_tuple(new_tuple3), hs_tuple(new_tuple4),
+            lambda hs_inner:cl.POINTER(new_tuple(*map(hs2py,tuple_types(hs_inner)))),
             default,default)
     return parse(hs_type)
 
@@ -78,7 +76,7 @@ def argtype(hs_type):
     parse = parse_generator(
             lambda _: partial(to_linked_list, argt._type_),
             lambda _: partial(to_c_array, argt._type_),
-            default, default, default, # Tuples
+            lambda _: partial(to_tuple, argt._type_),
             lambda _: lambda x: cl.pointer(cl.c_wchar_p(x)), # Strings
             default
             )
@@ -89,12 +87,10 @@ def restype(hs_type):
     returns: tuple : (type of result, reconstructor)
     '''
     rtype = hs2py(hs_type)
-    def restup(f):
-        return lambda hs_inner:lambda x:apply(lmap(restype,tuple_types(hs_inner)), f(x))
     parse = parse_generator(
         lambda hs_inner:lambda x:lmap(restype(hs_inner)[1],from_linked_list(x)),
         lambda hs_inner:lambda x:lmap(restype(hs_inner)[1],from_c_array(x)),
-        restup(from_tuple2), restup(from_tuple3), restup(from_tuple4),
+        lambda hs_inner:lambda x:apply(lmap(restype,tuple_types(hs_inner)), from_tuple(x)),
         lambda _:lambda x:x.contents.value,
         lambda _:lambda x:x)
     return rtype,parse(hs_type)

--- a/pythas/haskell/parse_type.py
+++ b/pythas/haskell/parse_type.py
@@ -63,9 +63,10 @@ def hs2py(hs_type):
     parse = parse_generator(
             lambda hs_inner:cl.POINTER(new_linked_list(hs2py(hs_inner))),
             lambda hs_inner:cl.POINTER(new_c_array(hs2py(hs_inner))),
-            lambda hs_inner:cl.POINTER(new_tuple(*map(hs2py,tuple_types(hs_inner)))),
+            lambda hs_inner:cl.POINTER(new_tuple(list(map(hs2py, tuple_types(hs_inner))))),
             default,default)
-    return parse(hs_type)
+    p = parse(hs_type)
+    return p
 
 def argtype(hs_type):
     '''

--- a/pythas/haskell/utils.py
+++ b/pythas/haskell/utils.py
@@ -54,29 +54,21 @@ def match_parens(s, i):
     else:
         return len(s)
 
-def parse_generator(f_llist, f_carray, f_tuple2, f_tuple3, f_tuple4, f_string, f_default):
+def parse_generator(f_llist, f_carray, f_tuple, f_string, f_default):
     def parser(hs_type):
         ll = hs_type.find('CList ')
         arr = hs_type.find('CArray ')
-        t2 = hs_type.find('CTuple2 ')
-        t3 = hs_type.find('CTuple3 ')
-        t4 = hs_type.find('CTuple4 ')
+        tup = hs_type.find('CTuple')
         st = hs_type.find('CWString')
         ## Linked List first
-        if ll+1 and (ll < arr or arr < 0) and (ll < t2 or t2 < 0) and (ll < t3 or t3 < 0) and (ll < t4 or t4 < 0):
+        if ll+1 and (ll < arr or arr < 0) and (ll < tup or tup < 0):
             return f_llist(hs_type[ll+len('CList '):])
         ## Array first
-        elif arr+1 and (arr < t2 or t2 < 0) and (arr < t3 or t3 < 0) and (arr < t4 or t4 < 0):
+        elif arr+1 and (arr < tup or tup < 0):
             return f_carray(hs_type[arr+len('CArray '):])
-        ## Tuple of 2 first
-        elif t2+1 and (t2 < t3 or t3 < 0) and (t2 < t4 or t4 < 0):
-            return f_tuple2(hs_type[t2+len('CTuple2 '):])
-        ## Tuple of 3 first
-        elif t3+1 and (t3 < t4 or t4 < 0):
-            return f_tuple3(hs_type[t3+len('CTuple3 '):])
-        ## Tuple of 4 first
-        elif t4+1:
-            return f_tuple4(hs_type[t4+len('CTuple4 '):])
+        ## Tuple first
+        elif tup+1:
+            return f_tuple(hs_type[tup+len('CTupleX '):])
         ## String first
         elif st+1:
             return f_string(hs_type[st+len('CWString '):])

--- a/pythas/haskell/utils.py
+++ b/pythas/haskell/utils.py
@@ -23,25 +23,24 @@ def tuple_types(hs_type):
     Nested tuples cannot just be .split(') ('), the
     inner tuples have to be preserved for further processing.
     '''
-    subtuples = [hs_type.find('CTuple')]
-    while subtuples[-1]+1:
-        subtuples.append(hs_type.find('CTuple',subtuples[-1]+1))
-    if len(subtuples) == 1:
-        return hs_type.split(') (')
-    else:
-        splits = [hs_type.find(') (',i)+1 if i != len(hs_type) else i
-                for i in map(lambda i: match_parens(hs_type,i-1), subtuples) if i
-            ]
-        res = [hs_type[a:b] for a,b in zip([0]+splits,splits+[len(hs_type)])]
-        return res
+    match = lambda x: match_parens(hs_type,x)
+    openp = hs_type.find('(')
+    closep = match(openp)
+    parens = [(openp, closep)]
+    while 1:
+        openp = hs_type.find('(',parens[-1][-1])
+        if openp == -1:
+            break
+        closep = match(openp)
+        parens.append((openp, closep))
+
+    return [hs_type[start:end] for start,end in parens]
 
 def match_parens(s, i):
     '''
     Given a string and the index of the opening
     parenthesis returns the index of the closing one.
     '''
-    if i < 0:
-        return 0
     x = 0
     for it in range(i,len(s)):
         c = s[it]

--- a/pythas/types.py
+++ b/pythas/types.py
@@ -75,7 +75,7 @@ def from_c_array(cp_array):
 class Tuple:
     pass
 
-def new_tuple(*subtypes):
+def new_tuple(subtypes):
     class c_tuple(Tuple, cl.Structure):
         _fields_ = list(zip("abcd",subtypes))
     return c_tuple

--- a/test/hs/TestLists.hs
+++ b/test/hs/TestLists.hs
@@ -20,8 +20,8 @@ listListInt = id
 listListString :: [[String]] -> [[String]]
 listListString = id
 
--- listListTupleStringString :: [[(String,String)]] -> [[(String, String)]]
--- listListTUpleStringString = id
+listListTupleStringString :: [[(String,String)]] -> [[(String, String)]]
+listListTupleStringString = id
 
 listListListString :: [[[String]]] -> [[[String]]]
 listListListString = id

--- a/test/hs/TestTupleIdentity.hs
+++ b/test/hs/TestTupleIdentity.hs
@@ -1,0 +1,25 @@
+module TestTupleIdentity where
+
+intInt :: (Int, Int) -> (Int, Int)
+intInt = id
+
+doubleDouble :: (Double, Double) -> (Double, Double)
+doubleDouble = id
+
+intCharDouble :: (Int, Char, Double) -> (Int, Char, Double)
+intCharDouble = id
+
+doubleFloatCharDouble :: (Double, Float, Char, Double) -> (Double, Float, Char, Double)
+doubleFloatCharDouble = id
+
+-- Lists and Nested
+
+intListStrings :: (Int, [String]) -> (Int, [String])
+intListStrings = id
+
+stringListTupleIntChar :: (String, [(Int, Char)]) -> (String, [(Int, Char)])
+stringListTupleIntChar = id
+
+nestedIntDouble :: ((Int, Double), (Int, Double)) -> ((Int, Double), (Int, Double))
+nestedIntDouble = id
+

--- a/test/test_lists.py
+++ b/test/test_lists.py
@@ -41,9 +41,9 @@ def test_listListInt(l):
 def test_listListString(l):
     assert hst.listListString(l) == l
 
-# @given(lists(lists(tuples(c_strings,c_strings))))
-# def test_listListTupleStringString(l):
-#     assert hst.listListTupleStringString(l) == l
+@given(lists(lists(tuples(c_strings,c_strings))))
+def test_listListTupleStringString(l):
+    assert hst.listListTupleStringString(l) == l
 
 @given(lists(lists(lists(c_strings))))
 def test_listListListString(l):

--- a/test/test_tuple_identity.py
+++ b/test/test_tuple_identity.py
@@ -1,0 +1,47 @@
+from hypothesis import given
+from hypothesis.strategies import integers, floats, binary, text, characters, tuples, lists
+
+from .context import pythas
+
+types = pythas.types
+utils = pythas.utils
+
+c_ints = integers(min_value=-46340,max_value=46340)
+c_floats = floats(allow_nan=False, width=32, allow_infinity=False)
+c_doubles = floats(allow_nan=False, allow_infinity=False)
+c_chars = binary(min_size=1,max_size=1)
+# ctypes stopped supporting embedded NULL characters
+c_strings = text(alphabet=characters(blacklist_characters='\0'))
+
+import test.hs.testtupleidentity as hst
+
+@given(tuples(c_ints, c_ints))
+def test_intInt(l):
+    assert hst.intInt(l) == l
+
+@given(tuples(c_doubles, c_doubles))
+def test_doubleDouble(l):
+    assert hst.doubleDouble(l) == l
+
+@given(tuples(c_ints, c_chars, c_doubles))
+def test_intCharDouble(l):
+    assert hst.intCharDouble(l) == l
+
+@given(tuples(c_doubles, c_floats, c_chars, c_doubles))
+def test_doubleFloatCharDouble(l):
+    assert hst.doubleFloatCharDouble(l) == l
+
+# Lists and Nested
+
+@given(tuples(c_ints, lists(c_strings)))
+def test_intListStrings(l):
+    assert hst.intListStrings(l) == l
+
+@given(tuples(c_strings, lists(tuples(c_ints, c_chars))))
+def test_stringListTupleIntChar(l):
+    assert hst.stringListTupleIntChar(l) == l
+
+@given(tuples(tuples(c_ints, c_doubles), tuples(c_ints, c_doubles)))
+def test_nestedIntDouble(l):
+    assert hst.nestedIntDouble(l) == l
+


### PR DESCRIPTION
Tuples as Arguments are now supported by Pythas-FFI and should also be supported by Pythas itself. This PR fixes tuple parsing in Python to enable this new feature.
It also adds tests and an example for tuples as arguments.