### PR TITLE
Make stack usage optional

### DIFF
--- a/pythas/compiler.py
+++ b/pythas/compiler.py
@@ -17,7 +17,7 @@ class Compiler:
 
     Attributes
     ----------
-    compiler : GHC
+    ghc : GHC
         More concrete implementation of the actual compiler.
     flags : tuple(str)
         Flags for `compiler`.
@@ -28,7 +28,7 @@ class Compiler:
         self._flags = list()
 
     @property
-    def compiler(self):
+    def ghc(self):
         return self.__compiler
 
     @property

--- a/pythas/compiler.py
+++ b/pythas/compiler.py
@@ -57,6 +57,22 @@ class Compiler:
         if flag in self._flags:
             self._flags.remove(flag)
 
+    def stack_usage(self, enabled):
+        """Enable the usage of stack for compilation.
+        Will default to False if stack is not available.
+
+        Parameters
+        ----------
+        enabled : bool
+            True if stack should be enabled.
+
+        Returns
+        -------
+        enabled : bool
+            True if stack is now enabled.
+        """
+        return self.__compiler.stack_usage(enabled)
+
     def compile(self, filename):
         """Creates an FFI file, compiles and links it against the
         Python runtime.

--- a/pythas/haskell/ghc.py
+++ b/pythas/haskell/ghc.py
@@ -164,6 +164,23 @@ class GHC:
         """
         self._optimisation = min(2, max(0, level))
 
+    def stack_usage(enabled):
+        """Enable the usage of stack for compilation.
+        Will default to False if stack is not available.
+
+        Parameters
+        ----------
+        enabled : bool
+            True if stack should be enabled.
+
+        Returns
+        -------
+        enabled : bool
+            True if stack is now enabled.
+        """
+        self._stack = enabled and has_stack()
+        return self._stack
+
     def compile(self, filepath, libpath, more_options=tuple(), _redirect=False):
         """Compile a Haskell source file to a shared library.
 

--- a/pythas/haskell/ghc.py
+++ b/pythas/haskell/ghc.py
@@ -164,7 +164,7 @@ class GHC:
         """
         self._optimisation = min(2, max(0, level))
 
-    def stack_usage(enabled):
+    def stack_usage(self, enabled):
         """Enable the usage of stack for compilation.
         Will default to False if stack is not available.
 

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -1,5 +1,4 @@
 from .context import pythas
-import test.hs.testcases as t
 
 from hypothesis import strategies, given
 
@@ -7,6 +6,7 @@ strings = strategies.text()
 tuples  = strategies.tuples
 
 def test_dynamic_dir():
+    import test.hs.testcases as t
     init_dir = set(dir(t))
     t.something = 63
     new_dir  = set(dir(t))
@@ -22,6 +22,11 @@ def test_sourcemodules():
             ''')
     assert m.i == 63
     assert m.f([('a','b'),('c','d')]) == 2
+
+def test_stack_switch():
+    pythas.compiler.ghc.stack_usage(False)
+    import test.hs.testcases as t
+    assert t.constantInt == 63
 
 @given(tuples(strings,strings), strings)
 def test_compilerflags(t,s):

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -24,7 +24,7 @@ def test_sourcemodules():
     assert m.f([('a','b'),('c','d')]) == 2
 
 def test_stack_switch():
-    pythas.compiler.ghc.stack_usage(False)
+    pythas.compiler.stack_usage(False)
     import test.hs.testcases as t
     assert t.constantInt == 63
 


### PR DESCRIPTION
This PR revises the API slightly and adds a switch to the ```GHC``` wrapper to enable/disable the usage of ```stack```.

Usage example:
~~~python
from pythas import compiler
is_stack_used = compiler.ghc.stack_usage(False)
print("Using stack") if is_stack_used else print("Not using stack")
~~~

Also adds a test to check the added functionality. Resolves #18 