### PR TITLE
Patch source modules ignore settings

### DIFF
--- a/pythas/compiler.py
+++ b/pythas/compiler.py
@@ -127,11 +127,22 @@ class SourceModule:
     ----------
     code : str
         The Haskell source code to wrap.
+    use_stack : bool
+        Use stack if available. Default value is True.
+    optimisation_level : int
+        The optimisation flag level to be used.
+        Maximum is 2, minimum is 0, default value is 2.
+    flags : Tuple[str]
+        Compile time flags to append. Default value is an empty tuple.
     """
-    def __init__(self, code):
+    def __init__(self, code, use_stack=True, optimisation_level=2, flags=tuple()):
         code = re.sub('\n[ \t]+','\n',code)
         haskell = 'module Temp where\n'+code
         compiler = Compiler()
+        compiler.stack_usage(use_stack)
+        compiler.ghc.optimisation(optimisation_level)
+        for flag in flags:
+            compiler.add_flag(flag)
 
         with tempfile.TemporaryDirectory() as dir:
             temp = os.path.join(dir,"Temp.hs")
@@ -150,3 +161,4 @@ class SourceModule:
         return list(self.__dict__) + self._exported
 
 compiler = Compiler()
+

--- a/pythas/compiler.py
+++ b/pythas/compiler.py
@@ -7,7 +7,7 @@ import tempfile
 import re
 import sys
 
-from .haskell import GHC, ffi_creator, has_stack, get_ghc_version
+from .haskell import GHC, ffi_creator, has_stack
 from .utils import shared_library_suffix, remove_created_files, \
                    flatten, custom_attr_getter, ffi_libs_exports
 from .parser import parse_haskell
@@ -44,7 +44,7 @@ class Compiler:
 
     @property
     def GHC_VERSION(self):
-        return get_ghc_version(self._stack)
+        return GHC.get_version(self._stack)
 
     @property
     def flags(self):

--- a/pythas/compiler.py
+++ b/pythas/compiler.py
@@ -26,8 +26,6 @@ class Compiler:
     ----------
     GHC_VERSION : str
         Version number string of the used GHC instance.
-    ghc : GHC
-        More concrete implementation of the actual compiler.
     flags : tuple(str)
         Flags for `compiler`.
     stack_usage : bool
@@ -36,7 +34,6 @@ class Compiler:
     """
     def __init__(self, flags=DEFAULT_FLAGS):
         self.__fficreator = ffi_creator
-        self.__compiler = GHC()
         self._flags = list(flags)
         self._stack = has_stack()
 
@@ -48,10 +45,6 @@ class Compiler:
     @property
     def GHC_VERSION(self):
         return get_ghc_version(self._stack)
-
-    @property
-    def ghc(self):
-        return self.__compiler
 
     @property
     def flags(self):
@@ -128,7 +121,7 @@ class Compiler:
                 delete = not windows
                 ) as lib_file:
 
-            self.__compiler.compile(name, lib_file.name, self.flags)
+            GHC.compile(name, lib_file.name, self.flags)
             if windows: lib_file.close()
             lib = cdll.LoadLibrary(lib_file.name)
 

--- a/pythas/haskell/__init__.py
+++ b/pythas/haskell/__init__.py
@@ -18,7 +18,7 @@ lib = os.path.join(dir, "libpythasffi")
 if not os.path.exists( lib ):
     lib += shared_library_suffix()
 
-GHC().compile(src, lib, _redirect=True)
+GHC.compile(src, lib, _redirect=True)
 
 ffi_creator = cdll.LoadLibrary( lib )
 ffi_creator.createFileBindings.argtype = [c_wchar_p]

--- a/pythas/haskell/__init__.py
+++ b/pythas/haskell/__init__.py
@@ -4,7 +4,7 @@ import os.path
 from ctypes import cdll, c_wchar_p, c_voidp
 from sys import platform
 
-from .ghc import GHC
+from .ghc import GHC, has_stack, get_ghc_version
 from ..utils import shared_library_suffix
 
 dir = os.path.join(

--- a/pythas/haskell/__init__.py
+++ b/pythas/haskell/__init__.py
@@ -4,7 +4,7 @@ import os.path
 from ctypes import cdll, c_wchar_p, c_voidp
 from sys import platform
 
-from .ghc import GHC, has_stack, get_ghc_version
+from .ghc import GHC, has_stack
 from ..utils import shared_library_suffix
 
 dir = os.path.join(

--- a/pythas/haskell/ghc.py
+++ b/pythas/haskell/ghc.py
@@ -137,8 +137,9 @@ def check_ghc_version(stack=has_stack()):
 
 class GHC:
     """Pythas interface class for GHC."""
-    def compile(self, filepath, libpath, use_stack=has_stack(), more_options=tuple(), _redirect=False):
-        """Compile a Haskell source file to a shared library.
+    @staticmethod
+    def compile(filepath, libpath, use_stack=has_stack(), more_options=tuple(), _redirect=False):
+        """Compiles a Haskell source file to a shared library.
 
         Parameters
         ----------
@@ -160,9 +161,9 @@ class GHC:
         """
         cwd = os.getcwd()
         os.chdir( os.path.dirname(filepath) )
-        flags = self.flags(filepath, libpath, use_stack, _redirect)
+        flags = GHC.flags(filepath, libpath, use_stack, _redirect)
         flags += more_options
-        cmd = self.ghc_compile_cmd(use_stack, flags)
+        cmd = GHC.ghc_compile_cmd(use_stack, flags)
 
         check_ghc_version()
         print('Compiling with: {}'.format(cmd[0]))
@@ -183,7 +184,8 @@ class GHC:
             os.chdir(cwd)
             return libpath
 
-    def flags(self, filename, libname, use_stack, _redirect=False):
+    @staticmethod
+    def flags(filename, libname, use_stack, _redirect=False):
         """Creates the flags needed for successful compilation of Haskell FFI files
         using Pythas.
 
@@ -244,7 +246,8 @@ class GHC:
 
         return flags
 
-    def ghc_compile_cmd(self, use_stack, options):
+    @staticmethod
+    def ghc_compile_cmd(use_stack, options):
         """Generates the compile command to GHC.
 
         Parameters

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -19,22 +19,25 @@ def test_sourcemodules():
 
             f :: [(String, String)] -> Int
             f = length
-            ''')
+            '''
+            , compiler = pythas.compiler
+            )
     assert m.i == 63
     assert m.f([('a','b'),('c','d')]) == 2
 
 def test_stack_switch():
-    pythas.compiler.stack_usage(False)
+    pythas.compiler.stack_usage = False
     import test.hs.testcases as t
     assert t.constantInt == 63
 
 @given(tuples(strings,strings), strings)
 def test_compilerflags(t,s):
+    base_flags = pythas.compiler.flags
     pythas.compiler.add_flag(t)
     pythas.compiler.add_flag(s)
-    assert pythas.compiler.flags == t + (s,)
+    assert pythas.compiler.flags == base_flags + t + (s,)
     pythas.compiler.remove_flag(t)
-    assert pythas.compiler.flags == (s,)
+    assert pythas.compiler.flags == base_flags + (s,)
     pythas.compiler.remove_flag(s)
-    assert pythas.compiler.flags == ()
+    assert pythas.compiler.flags == base_flags
 


### PR DESCRIPTION
Fixes #22 by completely revising the interrelation of the ```Compiler```, the ```SourceModule``` and the ```GHC``` class.

The API is now more pythonic by removing ambiguous variants for setting compile time options.Everything can now be set directly on the ```Compiler``` class. These options were then added to the ```SourceModule```, which now also accepts a ```Compiler``` instance as an alternative to making its own.